### PR TITLE
Addresses search exception when including reserved characters in search

### DIFF
--- a/search/elastic.py
+++ b/search/elastic.py
@@ -12,6 +12,12 @@ from search.utils import ValueRange
 # log appears to be standard name used for logger
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
+# These are characters that may have special meaning within Elasticsearch.
+# We _may_ want to use these for their special uses for certain queries,
+# but for analysed fields these kinds of characters are removed anyway, so
+# we can safely remove them from analysed matches
+RESERVED_CHARACTERS = "+-=><!(){}[]^\"~*:\\/&|?"
+
 
 def _translate_hits(es_response):
     """ Provide resultset in our desired format from elasticsearch results """
@@ -377,7 +383,7 @@ class ElasticSearchEngine(SearchEngine):
             elastic_queries.append({
                 "query_string": {
                     "fields": ["content.*"],
-                    "query": query_string
+                    "query": query_string.encode('utf-8').translate(None, RESERVED_CHARACTERS)
                 }
             })
 

--- a/search/tests/mock_search_engine.py
+++ b/search/tests/mock_search_engine.py
@@ -70,8 +70,7 @@ def _filter_intersection(documents_to_search, dictionary_object, include_blanks=
 
         if isinstance(field_value, ValueRange):
             return (
-                (field_value.lower is None or compare_value >= field_value.lower)
-                and
+                (field_value.lower is None or compare_value >= field_value.lower) and
                 (field_value.upper is None or compare_value <= field_value.upper)
             )
         else:


### PR DESCRIPTION
@mattdrayer - any chance you could look at this.

We were having a failure in the call to elasticsearch if the search included characters that are in the "reserved" characters for elasticsearch.

Since analyzing removes these characters anyway, we simply strip them out of our search term - the alternative is to escape them if we need to match, but that does not appear to be working in the elasticsearch version that we are currently using.