### PR TITLE
Support `None` value for filter_dictionary attribute

### DIFF
--- a/search/elastic.py
+++ b/search/elastic.py
@@ -105,16 +105,23 @@ def _process_filters(filter_dictionary):
     """
     def filter_item(field):
         """ format elasticsearch filter to pass if value matches OR field is not included """
-        return {
-            "or": [
-                _get_filter_field(field, filter_dictionary[field]),
-                {
-                    "missing": {
-                        "field": field
+        if filter_dictionary[field] is not None:
+            return {
+                "or": [
+                    _get_filter_field(field, filter_dictionary[field]),
+                    {
+                        "missing": {
+                            "field": field
+                        }
                     }
+                ]
+            }
+        else:
+            return {
+                "missing": {
+                    "field": field
                 }
-            ]
-        }
+            }
 
     return [filter_item(field) for field in filter_dictionary]
 

--- a/search/tests/tests.py
+++ b/search/tests/tests.py
@@ -394,6 +394,25 @@ class MockSearchTests(TestCase, SearcherMixin):
         response = self.searcher.search()
         self.assertEqual(response["total"], 3)
 
+    def test_filter_where_null(self):
+        """
+        Make sure that filtering with `None` value finds only fields where item
+        is not present or where explicitly None
+        """
+        self.searcher.index("test_doc", {"id": "FAKE_ID_1", "test_value": "1", "filter_field": "my_filter_value"})
+        self.searcher.index("test_doc", {"id": "FAKE_ID_2", "test_value": "2"})
+        self.searcher.index("test_doc", {"id": "FAKE_ID_3", "test_value": "3", "filter_field": "not_my_filter_value"})
+
+        response = self.searcher.search(filter_dictionary={"filter_field": "my_filter_value"})
+        self.assertEqual(response["total"], 2)
+
+        response = self.searcher.search(filter_dictionary={"filter_field": None})
+        self.assertEqual(response["total"], 1)
+
+        self.searcher.index("test_doc", {"id": "FAKE_ID_4", "test_value": "4", "filter_field": None})
+        response = self.searcher.search(filter_dictionary={"filter_field": None})
+        self.assertEqual(response["total"], 2)
+
     def test_date_range(self):
         """ Make sure that date ranges can be searched """
         self.searcher.index("test_doc", {"id": "FAKE_ID_1", "test_value": "1", "start_date": datetime(2010, 1, 1)})


### PR DESCRIPTION
so that explicit calls for when no value is specified are honoured.

@dino-cikatic - Please review this change, I think we'll want it to support SOL-495 correctly.
@dsego, @mattdrayer  - Seems like a small bug fix, so can either (or both) of you be the second reviewer(s)?