### PR TITLE
Add exclude filtering to allow for microsites

### DIFF
--- a/search/filter_generator.py
+++ b/search/filter_generator.py
@@ -27,6 +27,10 @@ class SearchFilterGenerator(object):
 
         return field_dictionary
 
+    def exclude_dictionary(self, **kwargs):
+        """ base implementation which excludes nothing """
+        return {}
+
     @classmethod
     def generate_field_filters(cls, **kwargs):
         """
@@ -34,4 +38,8 @@ class SearchFilterGenerator(object):
         Finds desired subclass and adds filter information based upon user information
         """
         generator = _load_class(getattr(settings, "SEARCH_FILTER_GENERATOR", None), cls)()
-        return generator.field_dictionary(**kwargs), generator.filter_dictionary(**kwargs)
+        return (
+            generator.field_dictionary(**kwargs),
+            generator.filter_dictionary(**kwargs),
+            generator.exclude_dictionary(**kwargs),
+        )

--- a/search/search_engine_base.py
+++ b/search/search_engine_base.py
@@ -23,7 +23,12 @@ class SearchEngine(object):
         """ This operation is called to remove a document of given type from the search index """
         raise NotImplementedError
 
-    def search(self, query_string=None, field_dictionary=None, filter_dictionary=None, exclude_ids=None, **kwargs):
+    def search(self,
+               query_string=None,
+               field_dictionary=None,
+               filter_dictionary=None,
+               exclude_dictionary=None,
+               **kwargs):
         """ This operation is called to search for matching documents within the search index """
         raise NotImplementedError
 


### PR DESCRIPTION
Addresses SOL-825 & SOL-826 (along with changes to platform - https://github.com/edx/edx-platform/pull/7914)

This change adds the ability for search clients to specify certain field/value pairs to exclude from results, which supports filtering-out of certain documents