### PR TITLE
Support None values in filter specification

### DIFF
--- a/search/tests/mock_search_engine.py
+++ b/search/tests/mock_search_engine.py
@@ -110,7 +110,7 @@ def _process_query_string(documents_to_search, search_strings):
         for name in dictionary_object:
             if isinstance(dictionary_object[name], dict):
                 return has_string(dictionary_object[name], search_string)
-            elif search_string.lower() in dictionary_object[name].lower():
+            elif dictionary_object[name] and search_string.lower() in dictionary_object[name].lower():
                 return True
         return False
 


### PR DESCRIPTION
@marjev, @dino-cikatic, @dsego  - easy fix to mock search engine to support where filtering upon `None` value. Any 2 thumbs will do!