### PR TITLE
Upgrade mock-django to 0.6.9

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ Django==1.7.3
 pymongo==2.4.1
 pytz
 elasticsearch==0.4.5
-mock-django==0.6.6
+mock-django==0.6.9
 mock==1.0.1
 
 # Our libraries:


### PR DESCRIPTION
Preparation for the [Django 1.8 upgrade](https://openedx.atlassian.net/wiki/display/TNL/Library+updates+needed+for+Django+upgrade+to+1.8)
