### PR TITLE
Elasticsearch Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache:
     - $HOME/.cache/pip
 
 before_install:
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.13.zip
-  - unzip elasticsearch-0.90.13.zip
-  - elasticsearch-0.90.13/bin/elasticsearch
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.zip
+  - unzip elasticsearch-1.5.2.zip
+  - elasticsearch-1.5.2/bin/elasticsearch -d
 
 
 install:

--- a/search/tests/tests.py
+++ b/search/tests/tests.py
@@ -369,16 +369,7 @@ class MockSearchTests(TestCase, SearcherMixin):
 
     def test_delete_item_not_present(self):
         """ make sure that we get no error removing an item that does not exist """
-        test_string = "This is a test of the emergency broadcast system"
-        self.searcher.index("test_doc", [{"id": "FAKE_ID", "content": {"name": "abc"}}])
-        self.searcher.remove("test_doc", ["FAKE_ID"])
-
-        response = self.searcher.search(test_string)
-        self.assertEqual(response["total"], 0)
-
-        self.searcher.remove("test_doc", ["FAKE_ID"])
-        response = self.searcher.search(test_string)
-        self.assertEqual(response["total"], 0)
+        self.searcher.remove("test_doc", ["TOTALLY_FAKE_ID"])
 
     def test_filter_items(self):
         """ Make sure that filters work """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='edx-search',
-    version='0.1.1',
+    version='1.0.0',
     description='Search and Index routines for index access',
     author='edX',
     url='https://github.com/edx/edx-search',
@@ -22,6 +22,6 @@ setup(
     packages=['search'],
     install_requires=[
         "django >= 1.8, < 1.9",
-        "elasticsearch<1.0.0"
+        "elasticsearch>=1.0.0,<2.0.0"
     ]
 )


### PR DESCRIPTION
Elasticsearch 0.90.x is quite out-of-date, and this requirement is preventing us from sharing an ES cluster with newer IDAs.

Also includes code/requirements cleanup.

ECOM-3261 and SOL-295

Merge #38 first.

Please review: @muhammad-ammar @macdiesel @andy-armstrong @bderusha 
FYI @cpennington @e0d @feanil