### PR TITLE
Install the tests subpackage as part of this package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='edx-search',
-    version='0.1.1',
+    version='0.1.2',
     description='Search and Index routines for index access',
     author='edX',
     author_email='oscm@edx.org',
@@ -20,7 +20,7 @@ setup(
         'Programming Language :: Python',
         'Framework :: Django',
     ],
-    packages=['search'],
+    packages=['search', 'search.tests'],
     install_requires=[
         "django >= 1.8, < 1.9",
         "elasticsearch<1.0.0"


### PR DESCRIPTION
This is required for tests in the edx-platform repo to run,
as they reference tests.mock_search_engine.

@clintonb 