### PR TITLE
Switch to using CodeCov for coverage checking.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+branch = True
+data_file = .coverage
+source=search

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,12 @@ before_install:
 
 
 install:
-  - "pip install -U pip wheel coveralls"
   - make requirements
 
 
 script: make validate
 
-after_success: coveralls
+after_success: codecov
 
 deploy:
   provider: pypi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto
+    patch:
+      default:
+        enabled: yes
+        target: 100%
+
+comment: false

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,6 +4,7 @@ edx-lint==0.4.0
 mock==1.3.0
 pep8==1.6.2
 pytz
+codecov
 
 
 # edX libraries


### PR DESCRIPTION
Removes Coveralls from our Travis builds and introduces CodeCov in its place.

@bjacobel could you confirm that this CodeCov report looks the way we expect it to?
@robrap for a second review.