### PR TITLE
Reduce set of reserved characters in Elastic searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 .coverage
 .idea/
+.tox

--- a/search/api.py
+++ b/search/api.py
@@ -27,6 +27,17 @@ class NoSearchEngineError(Exception):
     pass
 
 
+class QueryParseError(Exception):
+    """QueryParseError will be thrown if the query is malformed.
+
+    If a query has mismatched quotes (e.g. '"some phrase', return a
+    more specific exception so the view can provide a more helpful
+    error message to the user.
+
+    """
+    pass
+
+
 def perform_search(
         search_term,
         user=None,

--- a/search/tests/test_course_discovery.py
+++ b/search/tests/test_course_discovery.py
@@ -7,13 +7,15 @@
 """ Tests for search functionalty """
 import copy
 from datetime import datetime
+import ddt
 
+from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
 from elasticsearch import Elasticsearch
 
 from search.api import course_discovery_search, NoSearchEngineError
-from search.elastic import ElasticSearchEngine
+from search.elastic import ElasticSearchEngine, QueryParseError
 from search.tests.utils import SearcherMixin, TEST_INDEX_NAME
 from .mock_search_engine import MockSearchEngine
 
@@ -99,6 +101,9 @@ class TestMockCourseDiscoverySearch(TestCase, SearcherMixin):  # pylint: disable
             _elasticsearch = Elasticsearch()
             # Make sure that we are fresh
             _elasticsearch.indices.delete(index=TEST_INDEX_NAME, ignore=[400, 404])
+
+            # remove cached property mappings (along with everything else)
+            cache.clear()
 
             config_body = {}
             # ignore unexpected-keyword-arg; ES python client documents that it can be used
@@ -298,12 +303,65 @@ class TestMockCourseDiscoverySearch(TestCase, SearcherMixin):  # pylint: disable
 
 
 @override_settings(SEARCH_ENGINE="search.tests.utils.ForceRefreshElasticSearchEngine")
+@ddt.ddt
 class TestElasticCourseDiscoverySearch(TestMockCourseDiscoverySearch):
     """ version of tests that use Elastic Backed index instead of mock """
 
     def setUp(self):
         super(TestElasticCourseDiscoverySearch, self).setUp()
         self.searcher.index("doc_type_that_is_meaninless_to_bootstrap_index", [{"test_doc_type": "bootstrap"}])
+
+    def test_course_matching_empty_index(self):
+        """ Check for empty result count before indexing """
+        results = course_discovery_search("defensive")
+        self.assertEqual(results["total"], 0)
+
+    @ddt.data(
+        ('defensive', 1),
+        ('offensive', 2),
+        ('move', 3),
+        ('"offensive move"', 1),
+        ('"offensive move"', 1),
+        ('"highly-offensive"', 1),
+        ('"highly-offensive teams"', 1),
+    )
+    @ddt.unpack
+    # pylint: disable=arguments-differ
+    def test_course_matching(self, term, result_count):
+        """ Make sure that matches within content can be located and processed """
+        DemoCourse.get_and_index(self.searcher, {
+            "content": {
+                "short_description": "This is a defensive move",
+                "overview": "Defensive teams often win"
+            }
+        })
+
+        DemoCourse.get_and_index(self.searcher, {
+            "content": {
+                "short_description": "This is an offensive move",
+                "overview": "Offensive teams often win"
+            }
+        })
+
+        DemoCourse.get_and_index(self.searcher, {
+            "content": {
+                "short_description": "This is a hyphenated move",
+                "overview": "Highly-offensive teams often win"
+            }
+        })
+
+        results = course_discovery_search()
+
+        self.assertEqual(results["total"], 3)
+
+        results = course_discovery_search(term)
+        self.assertEqual(results["total"], result_count)
+
+    def test_malformed_query_handling(self):
+        """Make sure that mismatched quotes produce a specific exception. """
+
+        with self.assertRaises(QueryParseError):
+            course_discovery_search('"missing quote')
 
 
 @override_settings(SEARCH_ENGINE=None)

--- a/search/tests/test_course_discovery_views.py
+++ b/search/tests/test_course_discovery_views.py
@@ -2,9 +2,9 @@
 from django.test.utils import override_settings
 
 from search.tests.tests import TEST_INDEX_NAME
+from search.tests.utils import post_discovery_request
 from .test_views import MockSearchUrlTest
 from .test_course_discovery import DemoCourse
-from search.tests.utils import post_discovery_request
 
 # Any class that inherits from TestCase will cause too-many-public-methods pylint error
 # pylint: disable=too-many-public-methods
@@ -34,9 +34,6 @@ class DiscoveryUrlTest(MockSearchUrlTest):
         DemoCourse.get_and_index(
             self.searcher, {"content": {"short_description": "Find this one somehow"}}
         )
-
-    def tearDown(self):
-        super(DiscoveryUrlTest, self).tearDown()
 
     def test_search_from_url(self):
         """ test searching using the url """

--- a/search/tests/test_views.py
+++ b/search/tests/test_views.py
@@ -1,5 +1,6 @@
 """ High-level view tests"""
 from datetime import datetime
+import ddt
 
 from django.core.urlresolvers import Resolver404, resolve
 from django.test import TestCase
@@ -9,7 +10,7 @@ from mock import patch, call
 from search.search_engine_base import SearchEngine
 from search.tests.mock_search_engine import MockSearchEngine
 from search.tests.tests import TEST_INDEX_NAME
-from search.tests.utils import post_request, SearcherMixin
+from search.tests.utils import post_discovery_request, post_request, SearcherMixin
 
 
 # Any class that inherits from TestCase will cause too-many-public-methods pylint error
@@ -447,3 +448,82 @@ class BadIndexTest(TestCase, SearcherMixin):
         searcher = SearchEngine.get_search_engine(TEST_INDEX_NAME)
         with self.assertRaises(StandardError):
             searcher.index("courseware_content", [{"id": "FAKE_ID_3", "content": {"text": "Here comes the sun"}}])
+
+
+@override_settings(SEARCH_ENGINE="search.tests.utils.ForceRefreshElasticSearchEngine")
+@override_settings(ELASTIC_FIELD_MAPPINGS={"start_date": {"type": "date"}})
+@override_settings(COURSEWARE_INDEX_NAME=TEST_INDEX_NAME)
+@ddt.ddt
+class ElasticSearchUrlTest(TestCase, SearcherMixin):
+    """Elastic-specific tests"""
+    def setUp(self):
+        self.searcher.index(
+            "courseware_content",
+            [
+                {
+                    "course": "ABC/DEF/GHI",
+                    "id": "FAKE_ID_1",
+                    "content": {
+                        "text": "It seems like k-means clustering would work in this context."
+                    },
+                    "test_date": datetime(2015, 1, 1),
+                    "test_string": "ABC, It's easy as 123"
+                }
+            ]
+        )
+        self.searcher.index(
+            "courseware_content",
+            [
+                {
+                    "course": "ABC/DEF/GHI",
+                    "id": "FAKE_ID_2",
+                    "content": {
+                        "text": "It looks like k-means clustering could work in this context."
+                    }
+                }
+            ]
+        )
+        self.searcher.index(
+            "courseware_content",
+            [
+                {
+                    "course": "ABC/DEF/GHI",
+                    "id": "FAKE_ID_3",
+                    "content": {
+                        "text": "It looks like k means something different in this context."
+                    }
+                }
+            ]
+        )
+
+    @ddt.data(
+        # Quoted phrases
+        ('"in this context"', None, 3),
+        ('"in this context"', "ABC/DEF/GHI", 3),
+        ('"looks like"', None, 2),
+        ('"looks like"', "ABC/DEF/GHI", 2),
+        # Hyphenated phrases
+        ('k-means', None, 3),
+        ('k-means', "ABC/DEF/GHI", 3),
+    )
+    @ddt.unpack
+    def test_valid_search(self, query, course_id, result_count):
+        code, results = post_request({"search_string": query}, course_id)
+        self.assertTrue(199 < code < 300)
+        self.assertEqual(results["total"], result_count)
+
+    def test_malformed_query_handling(self):
+        # root
+        code, results = post_request({"search_string": "\"missing quote"})
+        self.assertGreater(code, 499)
+        self.assertEqual(results["error"], 'Your query seems malformed. Check for unmatched quotes.')
+
+        # course ID
+        code, results = post_request({"search_string": "\"missing quote"}, "ABC/DEF/GHI")
+        self.assertGreater(code, 499)
+        self.assertEqual(results["error"], 'Your query seems malformed. Check for unmatched quotes.')
+
+        # course discovery
+        code, results = post_discovery_request({"search_string": "\"missing quote"})
+        self.assertGreater(code, 499)
+        self.assertEqual(results["error"], 'Your query seems malformed. Check for unmatched quotes.')

--- a/search/tests/utils.py
+++ b/search/tests/utils.py
@@ -63,14 +63,18 @@ class ForceRefreshElasticSearchEngine(ElasticSearchEngine):
 class ErroringSearchEngine(MockSearchEngine):
     """ Override to generate search engine error to test """
 
-    def search(self, query_string=None, field_dictionary=None, filter_dictionary=None, **kwargs):
+    def search(self,
+               query_string=None,
+               field_dictionary=None,
+               filter_dictionary=None,
+               **kwargs):  # pylint: disable=arguments-differ
         raise StandardError("There is a problem here")
 
 
 class ErroringIndexEngine(MockSearchEngine):
     """ Override to generate search engine error to test """
 
-    def index(self, doc_type, sources, **kwargs):  # pylint: disable=unused-argument
+    def index(self, doc_type, sources, **kwargs):  # pylint: disable=unused-argument, arguments-differ
         raise StandardError("There is a problem here")
 
 
@@ -78,6 +82,6 @@ class ErroringElasticImpl(Elasticsearch):
     """ Elasticsearch implementation that throws exceptions"""
 
     # pylint: disable=unused-argument
-    def search(self, **kwargs):
+    def search(self, **kwargs):  # pylint: disable=arguments-differ
         """ this will definitely fail """
         raise exceptions.ElasticsearchException("This search operation failed")

--- a/search/views.py
+++ b/search/views.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from eventtracking import tracker as track
-from .api import perform_search, course_discovery_search, course_discovery_filter_fields
+from .api import QueryParseError, perform_search, course_discovery_search, course_discovery_filter_fields
 from .initializer import SearchInitializer
 
 # log appears to be standard name used for logger
@@ -124,6 +124,11 @@ def do_search(request, course_id=None):
         }
         log.debug(unicode(invalid_err))
 
+    except QueryParseError:
+        results = {
+            "error": _('Your query seems malformed. Check for unmatched quotes.')
+        }
+
     # Allow for broad exceptions here - this is an entry point from external reference
     except Exception as err:  # pylint: disable=broad-except
         results = {
@@ -213,6 +218,11 @@ def course_discovery(request):
             "error": unicode(invalid_err)
         }
         log.debug(unicode(invalid_err))
+
+    except QueryParseError:
+        results = {
+            "error": _('Your query seems malformed. Check for unmatched quotes.')
+        }
 
     # Allow for broad exceptions here - this is an entry point from external reference
     except Exception as err:  # pylint: disable=broad-except

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='edx-search',
-    version='1.1.0',
+    version='1.2.0',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,12 +1,12 @@
 -e .
 coverage==4.0.3
-edx-lint==0.4.0
+ddt
+edx-lint==0.5.5
 mock==1.3.0
 pep8==1.6.2
 pytz
 codecov
 tox>=2.3.1,<3.0.0
-
 
 # edX libraries
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking


### PR DESCRIPTION
Remove the hyphen and double quote from the list of reserved characters in Elastic searches, allowing more effective searches for hyphenated terms and quoted phrases.
    
This introduces the possibility of Elastic rejecting malformed quoted queries, so additional exception handling is provided for that case. Actually presenting the more specific errors to users requires changes in edx-platform; installing this revision of edx-search without those changes will result in malformed queries producing the same "There was an error, try searching again." message any search error returns.

**Testing instructions**:

To test manually:

1. Enable search in your devstack by setting the following settings to True in cms/envs/devstack_docker.py and lms/envs/devstack_docker.py:

* ENABLE_COURSEWARE_SEARCH
* ENABLE_COURSE_DISCOVERY
* ENABLE_DASHBOARD_SEARCH

2. Add an HTML Text unit to a course in your devstack with text containing a hyphenated term (e.g. "k-means" or phrase ("smoke test") to search for. Bonus points if the phrase contains a word contained in text of other courses.

3. Search for the hyphenated term or quoted phrase. If you're looking for "smoke test", you shouldn't get courses that just contain the word "test"; the search should only return the course containing the complete phrase.

To run the edx-search test suite, you need to mimic the steps in .travis.yml:

1. Create and activate a Python 2.7 virtualenv.

2. Install the specific version of ElasticSearch used in the tests:
  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.zip
  - unzip elasticsearch-1.5.2.zip
  - elasticsearch-1.5.2/bin/elasticsearch -d

3. Install the test requirements in the virtualenv by running `make requirements`.

4. Run the test suite with `make validate`.

**Reviewers**
- [ ] pomegranited
- [ ] edX reviewer[s] TBD