### PR TITLE
Updated Elasticsearch version to latest supported by haystack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ cache:
     - $HOME/.cache/pip
 
 before_install:
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.zip
-  - unzip elasticsearch-1.5.2.zip
-  - elasticsearch-1.5.2/bin/elasticsearch -d
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.0.zip
+  - unzip elasticsearch-5.6.0.zip
+  - elasticsearch-5.6.0/bin/elasticsearch -d
 
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     packages=['search', 'search.tests'],
     install_requires=[
         "django >= 1.8, < 2.0",
-        "elasticsearch>=1.0.0,<2.0.0"
+        "elasticsearch>=1.0.0,<6.0"
     ]
 )


### PR DESCRIPTION
In order to stay up to date with Haystack and Elasticsearch I loosened the version pin to allow for 5.x versions and updated the `.travis.yml` to install the 5.6 release for testing.