### PR TITLE
Remove hardcoded field filter to allow custom discovery search fields

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -81,12 +81,9 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
     """
     Course Discovery activities against the search engine index of course details
     """
-    # We'll ignore the course-enrollemnt informaiton in field and filter
-    # dictionary, and use our own logic upon enrollment dates for these
-    use_search_fields = ["org"]
     (search_fields, _, exclude_dictionary) = SearchFilterGenerator.generate_field_filters()
     use_field_dictionary = {}
-    use_field_dictionary.update({field: search_fields[field] for field in search_fields if field in use_search_fields})
+    use_field_dictionary.update(search_fields)
     if field_dictionary:
         use_field_dictionary.update(field_dictionary)
     if not getattr(settings, "SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING", False):


### PR DESCRIPTION
Course discovery was unable to use SearchFilterGenerator for custom field filters because it only recognized `org`. In our case for example, we needed to autofilter with a select group of course ids.
This change is backwards compatible.

@nedbat 