### PR TITLE
Allow discovery search results to be sorted

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -104,6 +104,7 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         filter_dictionary={"enrollment_end": DateRange(datetime.utcnow(), None)},
         exclude_dictionary=exclude_dictionary,
         facet_terms=course_discovery_facets(),
+        sort=getattr(settings, 'SEARCH_DISCOVERY_SORT_FIELDS', ''),
     )
 
     return results

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.2.3',
+    version='1.3.0',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
Our instance needs this for the empty query to return the courses sorted by their start date.