### PR TITLE
Updating openedx.yaml to confirm OEP-7 compliance

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -6,7 +6,7 @@ owner: fysheets
 
 oeps:
     oep-2: true
-    oep-7: false
+    oep-7: true
     oep-18: false
 tags:
     - dedx


### PR DESCRIPTION
## [PROD-387](https://openedx.atlassian.net/browse/PROD-387)

edx-search already complied with OEP-7 due to this [PR](https://github.com/edx/edx-search/pull/65). Here I just update the openedx.yaml to reflect true state of repository. 