### PR TITLE
Travis CI's default distro is now Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-# dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 python:
   - 2.7
   - 3.6


### PR DESCRIPTION
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment