### PR TITLE
debugging-root-cause of tests failures in edx-platform

### DIFF
--- a/edxsearch/wsgi.py
+++ b/edxsearch/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for edxsearch project.
+WSGI config for edxsearch project
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 

--- a/search/api.py
+++ b/search/api.py
@@ -81,9 +81,10 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
     """
     Course Discovery activities against the search engine index of course details
     """
+    use_search_fields = ["org"]
     (search_fields, _, exclude_dictionary) = SearchFilterGenerator.generate_field_filters()
     use_field_dictionary = {}
-    use_field_dictionary.update(search_fields)
+    use_field_dictionary.update({field: search_fields[field] for field in search_fields if field in use_search_fields})
     if field_dictionary:
         use_field_dictionary.update(field_dictionary)
     if not getattr(settings, "SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING", False):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1036

edx-platform has a [version constrain](https://github.com/edx/edx-platform/blob/master/requirements/constraints.txt#L50) for this repo. edx-search==1.3.1 is available but platform is using 1.2.2. I have tried to debug the failure and I think this [PR](https://github.com/edx/edx-search/pull/71) is the root cause.

I have revert those changes in this PR and created [PR](https://github.com/edx/edx-platform/pull/22338) in edx-platform.

I got the root cause, you can see in below section.

For test failures you can check this [PR](https://github.com/edx/edx-platform/pull/22343). It is using latest version.