### PR TITLE
Revert "Allow discovery search results to be sorted"

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -104,7 +104,6 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         filter_dictionary={"enrollment_end": DateRange(datetime.utcnow(), None)},
         exclude_dictionary=exclude_dictionary,
         facet_terms=course_discovery_facets(),
-        sort=getattr(settings, 'SEARCH_DISCOVERY_SORT_FIELDS', ''),
     )
 
     return results

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.3.1',
+    version='1.3.2',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
This reverts commit a202ec5b635061bb0ecbe67e645aa773d692cea7.

Also bump version number up.

This commit caused tests to fail on edx-platform. This revert should allow us to use the latest version of edx-search on edx-platform again.

https://openedx.atlassian.net/browse/BOM-1036