### PR TITLE
Relax Django constraint for upgrade to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,27 @@
 language: python
 
+python:
+- 3.5
+
+envs:
+- TOXENV=django111
+- TOXENV=django20
+- TOXENV=django21
+- TOXENV=django22
+- TOXENV=quality
+
 matrix:
   include:
     - python: 2.7
       env: TOXENV=quality
     - python: 2.7
       env: TOXENV=django111
-    - python: 3.5
-      env: TOXENV=quality
-    - python: 3.5
-      env: TOXENV=django111
-    - python: 3.6
-      env: TOXENV=django20
-    - python: 3.6
-      env: TOXENV=django21
     - python: 3.6
       env: TOXENV=django22
-    - python: 3.6
-      env: TOXENV=quality
-    - python: 3.7
-      env: TOXENV=django20
-    - python: 3.7
-      env: TOXENV=django21
     - python: 3.7
       env: TOXENV=django22
-    - python: 3.7
-      env: TOXENV=quality
-  allow_failures:
-    - python: 3.6
-    - python: 3.7
+    - python: 3.8
+      env: TOXENV=django22
 
 addons:
   apt:

--- a/edxsearch/settings.py
+++ b/edxsearch/settings.py
@@ -26,9 +26,22 @@ SECRET_KEY = os.environ.get('SECRET_KEY', '@krr4&!u8#g&2^(q53e3xu_kux$3rm=)7s3m1
 # This is just a container for running tests
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = []
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': (
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            )
+        }
+    },
+]
 
 
 # Application definition

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,7 @@
 -c constraints.txt
 
 
-Django<2                     # Web application framework
+Django                       # Web application framework
 elasticsearch>=1.0.0,<2.0.0
 event-tracking
 six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,10 @@
 #
 #    make upgrade
 #
-django==1.11.26
-elasticsearch==1.9.0
-event-tracking==0.3.0
-pymongo==3.9.0            # via event-tracking
+django==1.11.29           # via -r requirements/base.in, event-tracking
+elasticsearch==1.9.0      # via -r requirements/base.in
+event-tracking==0.3.0     # via -r requirements/base.in
+pymongo==3.10.1           # via event-tracking
 pytz==2019.3              # via django, event-tracking
-six==1.13.0
-urllib3==1.25.7           # via elasticsearch
+six==1.14.0               # via -r requirements/base.in, event-tracking
+urllib3==1.25.8           # via elasticsearch

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,53 +4,56 @@
 #
 #    make upgrade
 #
-astroid==1.6.6
-backports.functools-lru-cache==1.6.1
-certifi==2019.9.11
-chardet==3.0.4
-click-log==0.3.2
-click==7.0
-codecov==2.0.15
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-ddt==1.2.1
-django==1.11.26
-edx-lint==1.4.1
-elasticsearch==1.9.0
-enum34==1.1.6
-event-tracking==0.3.0
-filelock==3.0.12
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"
-idna==2.8
-importlib-metadata==0.23
-isort==4.3.21
-lazy-object-proxy==1.4.3
-mccabe==0.6.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pip-tools==4.2.0
-pluggy==0.13.0
-py==1.8.0
-pycodestyle==2.5.0
-pylint-celery==0.3
-pylint-django==0.11.1
-pylint-plugin-utils==0.6
-pylint==1.9.5
-pymongo==3.9.0
-pyparsing==2.4.5
-pytz==2019.3
-requests==2.22.0
-scandir==1.10.0
-singledispatch==3.4.0.3
-six==1.13.0
-toml==0.10.0
-tox-battery==0.5.1
-tox==3.14.1
-urllib3==1.25.7
-virtualenv==16.7.7
-wrapt==1.11.2
-zipp==0.6.0
+appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
+astroid==1.6.6            # via -r requirements/quality.txt, pylint, pylint-celery
+backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, astroid, isort, pylint
+certifi==2019.11.28       # via -r requirements/travis.txt, requests
+chardet==3.0.4            # via -r requirements/travis.txt, requests
+click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
+click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
+codecov==2.0.22           # via -r requirements/travis.txt
+configparser==4.0.2       # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv, zipp
+coverage==5.0.4           # via -r requirements/quality.txt, -r requirements/testing.txt, -r requirements/travis.txt, codecov
+ddt==1.3.1                # via -r requirements/quality.txt, -r requirements/testing.txt
+distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
+django==1.11.29           # via -r requirements/quality.txt, -r requirements/testing.txt, event-tracking
+edx-lint==1.4.1           # via -r requirements/quality.txt
+elasticsearch==1.9.0      # via -r requirements/quality.txt, -r requirements/testing.txt
+enum34==1.1.10            # via -r requirements/quality.txt, astroid
+event-tracking==0.3.0     # via -r requirements/quality.txt, -r requirements/testing.txt
+filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+funcsigs==1.0.2           # via -r requirements/quality.txt, -r requirements/testing.txt, mock
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/quality.txt, isort
+idna==2.9                 # via -r requirements/travis.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/travis.txt, importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
+isort==4.3.21             # via -r requirements/quality.txt, pylint
+lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
+mccabe==0.6.1             # via -r requirements/quality.txt, pylint
+mock==3.0.5               # via -r requirements/quality.txt, -r requirements/testing.txt
+packaging==20.3           # via -r requirements/travis.txt, tox
+pathlib2==2.3.5           # via -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv
+pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/travis.txt, tox
+py==1.8.1                 # via -r requirements/travis.txt, tox
+pycodestyle==2.5.0        # via -r requirements/quality.txt
+pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
+pylint-django==0.11.1     # via -r requirements/quality.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
+pylint==1.9.5             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/quality.txt, -r requirements/testing.txt, event-tracking
+pyparsing==2.4.6          # via -r requirements/travis.txt, packaging
+pytz==2019.3              # via -r requirements/quality.txt, -r requirements/testing.txt, django, event-tracking
+requests==2.23.0          # via -r requirements/travis.txt, codecov
+scandir==1.10.0           # via -r requirements/travis.txt, pathlib2
+singledispatch==3.4.0.3   # via -r requirements/quality.txt, -r requirements/travis.txt, astroid, importlib-resources, pylint
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/testing.txt, -r requirements/travis.txt, astroid, edx-lint, event-tracking, mock, packaging, pathlib2, pip-tools, pylint, singledispatch, tox, virtualenv
+toml==0.10.0              # via -r requirements/travis.txt, tox
+tox-battery==0.5.2        # via -r requirements/travis.txt
+tox==3.14.6               # via -r requirements/travis.txt, tox-battery
+typing==3.7.4.1           # via -r requirements/travis.txt, importlib-resources
+urllib3==1.25.8           # via -r requirements/quality.txt, -r requirements/testing.txt, -r requirements/travis.txt, elasticsearch, requests
+virtualenv==20.0.15       # via -r requirements/travis.txt, tox
+wrapt==1.12.1             # via -r requirements/quality.txt, astroid
+zipp==1.2.0               # via -r requirements/travis.txt, importlib-metadata, importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.2.0
-six==1.13.0               # via pip-tools
+click==7.1.1              # via pip-tools
+pip-tools==4.5.1          # via -r requirements/pip-tools.in
+six==1.14.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -7,29 +7,29 @@
 astroid==1.6.6            # via pylint, pylint-celery
 backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
 click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, edx-lint
+click==7.1.1              # via click-log, edx-lint
 configparser==4.0.2       # via pylint
-coverage==4.5.4
-ddt==1.2.1
-django==1.11.26
-edx-lint==1.4.1
-elasticsearch==1.9.0
-enum34==1.1.6             # via astroid
-event-tracking==0.3.0
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"  # via isort
+coverage==5.0.4           # via -r requirements/quality.in, -r requirements/testing.txt
+ddt==1.3.1                # via -r requirements/testing.txt
+django==1.11.29           # via -r requirements/testing.txt, event-tracking
+edx-lint==1.4.1           # via -r requirements/quality.in
+elasticsearch==1.9.0      # via -r requirements/testing.txt
+enum34==1.1.10            # via astroid
+event-tracking==0.3.0     # via -r requirements/testing.txt
+funcsigs==1.0.2           # via -r requirements/testing.txt, mock
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-mock==3.0.5
-pycodestyle==2.5.0
+mock==3.0.5               # via -r requirements/testing.txt
+pycodestyle==2.5.0        # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.11.1     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.9.0
-pytz==2019.3
+pymongo==3.10.1           # via -r requirements/testing.txt, event-tracking
+pytz==2019.3              # via -r requirements/testing.txt, django, event-tracking
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.13.0
-urllib3==1.25.7
-wrapt==1.11.2             # via astroid
+six==1.14.0               # via -r requirements/testing.txt, astroid, edx-lint, event-tracking, mock, pylint, singledispatch
+urllib3==1.25.8           # via -r requirements/testing.txt, elasticsearch
+wrapt==1.12.1             # via astroid

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-coverage==4.5.4
-ddt==1.2.1
-elasticsearch==1.9.0
-event-tracking==0.3.0
+coverage==5.0.4           # via -r requirements/testing.in
+ddt==1.3.1                # via -r requirements/testing.in
+elasticsearch==1.9.0      # via -r requirements/base.txt
+event-tracking==0.3.0     # via -r requirements/base.txt
 funcsigs==1.0.2           # via mock
-mock==3.0.5
-pymongo==3.9.0
-pytz==2019.3
-six==1.13.0
-urllib3==1.25.7
+mock==3.0.5               # via -r requirements/testing.in
+pymongo==3.10.1           # via -r requirements/base.txt, event-tracking
+pytz==2019.3              # via -r requirements/base.txt, django, event-tracking
+six==1.14.0               # via -r requirements/base.txt, event-tracking, mock
+urllib3==1.25.8           # via -r requirements/base.txt, elasticsearch

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,27 +4,31 @@
 #
 #    make upgrade
 #
-certifi==2019.9.11        # via requests
+appdirs==1.4.3            # via virtualenv
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15
+codecov==2.0.22           # via -r requirements/travis.in
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==4.5.4           # via codecov
-filelock==3.0.12          # via tox
-idna==2.8                 # via requests
-importlib-metadata==0.23  # via pluggy, tox
-more-itertools==5.0.0     # via zipp
-packaging==19.2           # via tox
-pathlib2==2.3.5           # via importlib-metadata
-pluggy==0.13.0            # via tox
-py==1.8.0                 # via tox
-pyparsing==2.4.5          # via packaging
-requests==2.22.0          # via codecov
+contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
+coverage==5.0.4           # via codecov
+distlib==0.3.0            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
+packaging==20.3           # via tox
+pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
+pluggy==0.13.1            # via tox
+py==1.8.1                 # via tox
+pyparsing==2.4.6          # via packaging
+requests==2.23.0          # via codecov
 scandir==1.10.0           # via pathlib2
-six==1.13.0               # via more-itertools, packaging, pathlib2, tox
+singledispatch==3.4.0.3   # via importlib-resources
+six==1.14.0               # via packaging, pathlib2, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.1
-urllib3==1.25.7           # via requests
-virtualenv==16.7.7        # via tox
-zipp==0.6.0               # via importlib-metadata
+tox-battery==0.5.2        # via -r requirements/travis.in
+tox==3.14.6               # via -r requirements/travis.in, tox-battery
+typing==3.7.4.1           # via importlib-resources
+urllib3==1.25.8           # via requests
+virtualenv==20.0.15       # via tox
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/settings.py
+++ b/settings.py
@@ -26,9 +26,22 @@ SECRET_KEY = os.environ.get('SECRET_KEY', '@krr4&!u8#g&2^(q53e3xu_kux$3rm=)7s3m1
 # This is just a container for running tests
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = []
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': (
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            )
+        }
+    },
+]
 
 
 # Application definition

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_requirement(line):
 
 setup(
     name='edx-search',
-    version='1.3.3',
+    version='1.3.4',
     description='Search and index routines for index access',
     author='edX',
     author_email='oscm@edx.org',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django111,py35-django{111,20,21,22},py{36,37}-django{111,20,21,22}, quality
+envlist = py27-django111,py35-django{111,20,21,22},py{36,37,38}-django22,quality
 
 [testenv]
 setenv =


### PR DESCRIPTION
- Unconstrain Django for 2.2 upgrade
- Remove `TEMPLATE_DEBUG` setting, which is deprecated
- Add templates definition -- required for admin app in Django 2.2
- Include py35-django22 testing
- Drop testing on Python > 3.5 except for most recent Django (quality check fails for these due to dependency conflict; probably will not be a problem when 2.7 is dropped)