### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# edx-search [![Build Status](https://travis-ci.org/edx/edx-search.svg?branch=master)](https://travis-ci.org/edx/edx-search) [![Coverage Status](https://coveralls.io/repos/edx/edx-search/badge.svg?branch=master&service=github)](https://coveralls.io/github/edx/edx-search?branch=master)
+# edx-search [![Build Status](https://travis-ci.com/edx/edx-search.svg?branch=master)](https://travis-ci.com/edx/edx-search) [![Coverage Status](https://coveralls.io/repos/edx/edx-search/badge.svg?branch=master&service=github)](https://coveralls.io/github/edx/edx-search?branch=master)
 
 This is a django application to provide access to search services from within edx-platform applications.
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089