### PR TITLE
fix: use correct logical operator for list values in search fields

### DIFF
--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -402,17 +402,21 @@ def get_search_params(
 
 def get_filter_rules(
     rule_dict: dict[str, t.Any], exclude: bool = False, optional: bool = False
-) -> list[str]:
+) -> list[str | list[str]]:
     """
     Convert inclusion/exclusion rules.
     """
     rules = []
     for key, value in rule_dict.items():
         if isinstance(value, list):
-            for v in value:
-                rules.append(
-                    get_filter_rule(key, v, exclude=exclude, optional=optional)
-                )
+            key_rules = [
+                get_filter_rule(key, v, exclude=exclude, optional=optional)
+                for v in value
+            ]
+            if exclude:
+                rules.extend(key_rules)
+            else:
+                rules.append(key_rules)
         else:
             rules.append(
                 get_filter_rule(key, value, exclude=exclude, optional=optional)

--- a/search/tests/test_meilisearch.py
+++ b/search/tests/test_meilisearch.py
@@ -232,6 +232,19 @@ class EngineTests(django.test.TestCase):
             'org = "testorg"',
         ] == params["filter"]
 
+    def test_engine_search_orgs_list(self):
+        params = search.meilisearch.get_search_params(
+            field_dictionary={
+                'mode': 'honor',
+                "org": ["testorg", "testorg2"],
+            }
+        )
+
+        assert [
+            'mode = "honor"',
+            ['org = "testorg"', 'org = "testorg2"'],
+        ] == params["filter"]
+
     def test_search_params_filter_dictionary(self):
         params = search.meilisearch.get_search_params(
             filter_dictionary={"key": "value"}


### PR DESCRIPTION
## Description
Discover courses pages shows 0 courses if the `course_org_filter` value is set. When course_org_filter contains a list of organizations (e.g., ["MITx", "HarvardX"]), the filter was incorrectly using AND logic instead of OR, causing zero results since a course can only belong to one organization.

### Previous behavior:
- course_org = "MITx" AND course_org = "HarvardX" → no matches
- Filter returns = ['org = "MITx"', 'org = "HarvardX"', 'mode = "honor"',] 

### Fixed behavior:
- course_org = "MITx" OR course_org = "HarvardX" → returns courses from either org
- Filter returns = [['org = "MITx"', 'org = "HarvardX"'], 'mode = "honor"'] 

### Refactor get_filter_rules() so it:
- Wraps same key values in an inner array so OR is applied
- Excludes `exclude_dictionary` from this because we don't want to join NOT operations

### Meilisearch Docs
- Inner array elements are connected by an `OR` operator.
- Outer array elements are connected by an `AND` operator
