### PR TITLE
fix: "Explore courses" search wasn't working with Typesense

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This is a django application to provide access to search services from within ed
 
 Searching is accomplished by creating an index of documents, and then searching within that index for matching information. This application provides a way to add documents to the index, and then search for them.
 
+## Meilisearch Engine
+
+edx-search includes full support for Meilisearch, and it is the default search engine in recent Open edX releases.
+
 ## Typesense Engine
 
-edx-search includes an optional `TypesenseEngine` backend (`search.typesense.TypesenseEngine`).
+edx-search includes an optional `TypesenseEngine` backend (`search.typesense.TypesenseEngine`), which can be used as an alternative to Meilisearch or Elasticsearch. See ["Use Typesense search backend"](https://docs.openedx.org/en/latest/site_ops/how-tos/use_typesense_search_backend.html) in the site operator documentation for instructions on setting it up, if you'd like to use it.
 
 ### Server version requirement
 
@@ -19,25 +23,6 @@ edx-search includes an optional `TypesenseEngine` backend (`search.typesense.Typ
 If you are running an older Typesense server you must upgrade it before deploying this version of edx-search.
 
 See the full compatibility table at https://github.com/typesense/typesense-python#compatibility.
-
-### Enabling the Typesense engine
-
-If you're using Tutor, the easiest way to use Typesense is to install [tutor-contrib-typesense](https://github.com/open-craft/tutor-contrib-typesense/). To configure it manually, you'll need to update these CMS/LMS settings:
-
-```python
-SEARCH_ENGINE = "search.typesense.TypesenseEngine"
-FORUM_SEARCH_BACKEND = "forum.search.typesense.TypesenseBackend"
-TYPESENSE_URLS = ["http://typesense:8108"]
-TYPESENSE_PUBLIC_URL = "http://typesense.example.com:8108"
-TYPESENSE_API_KEY: "..."
-```
-
-After switching, create the indices using the shell (no management command exists yet — see
-https://github.com/openedx/edx-platform/issues/36868 for the longer-term plan):
-
-```shell
-./manage.py lms shell -c "import search.typesense; search.typesense.create_indexes()"
-```
 
 ## SearchEngine
 The SearchEngine is an abstract object which may have multiple implementations. As of Verawood, there are four in existence:

--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ See the full compatibility table at https://github.com/typesense/typesense-pytho
 
 ### Enabling the Typesense engine
 
+If you're using Tutor, the easiest way to use Typesense is to install [tutor-contrib-typesense](https://github.com/open-craft/tutor-contrib-typesense/). To configure it manually, you'll need to update these CMS/LMS settings:
+
 ```python
 SEARCH_ENGINE = "search.typesense.TypesenseEngine"
+FORUM_SEARCH_BACKEND = "forum.search.typesense.TypesenseBackend"
+TYPESENSE_URLS = ["http://typesense:8108"]
+TYPESENSE_PUBLIC_URL = "http://typesense.example.com:8108"
+TYPESENSE_API_KEY: "..."
 ```
 
-You will also need to configure the Typesense connection in your Django settings (host, port, API key).
 After switching, create the indices using the shell (no management command exists yet — see
 https://github.com/openedx/edx-platform/issues/36868 for the longer-term plan):
 

--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '5.0.0'
+__version__ = '5.0.1'

--- a/search/typesense.py
+++ b/search/typesense.py
@@ -192,7 +192,7 @@ class TypesenseEngine(SearchEngine):
 
     def search(
         self,
-        query_string="",
+        query_string: str | None = "",
         field_dictionary=None,
         filter_dictionary=None,
         exclude_dictionary=None,
@@ -221,7 +221,7 @@ class TypesenseEngine(SearchEngine):
         # just using filters).
         index_config = INDEX_CONFIGURATION[self.index_name]
         query_by = index_config["query_fields"]
-        search_args = {"q": query_string, "query_by": query_by, **compiled_params}
+        search_args = {"q": query_string or "", "query_by": query_by, **compiled_params}
         try:
             results = self.typesense_index.documents.search(search_args)
         except (RequestMalformed, httpx.InvalidURL) as err:


### PR DESCRIPTION
Browsing courses at http://apps.local.openedx.io:1998/catalog/courses seems to no longer be working with Typesense. I suspect it was the upgrade to Typesense 2, but it could have been some other change.

The error seen is:
```
lms-1        | 2026-05-05 00:43:00,335 ERROR 104 [search.views] [user 4] [ip 192.168.65.1] views.py:233 - Search view exception when searching for None for user 4: InvalidParameter('Value None is not a string, integer, or boolean')
lms-1        | Traceback (most recent call last):
lms-1        |   File "/mnt/edx-search/search/views.py", line 201, in _course_discovery
lms-1        |     results = course_discovery_search(
lms-1        |               ^^^^^^^^^^^^^^^^^^^^^^^^
lms-1        |   File "/mnt/edx-search/search/api.py", line 159, in course_discovery_search
lms-1        |     results = searcher.search(
lms-1        |               ^^^^^^^^^^^^^^^^
lms-1        |   File "/mnt/edx-search/search/typesense.py", line 211, in search
lms-1        |     results = self.typesense_index.documents.search(search_args)
lms-1        |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1        |   File "/openedx/venv/lib/python3.12/site-packages/typesense/sync/documents.py", line 340, in search
lms-1        |     stringified_search_params = stringify_search_params(search_parameters)
lms-1        |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1        |   File "/openedx/venv/lib/python3.12/site-packages/typesense/preprocess.py", line 144, in stringify_search_params
lms-1        |     raise InvalidParameter(
lms-1        | typesense.exceptions.InvalidParameter: Value None is not a string, integer, or boolean
lms-1        | Internal Server Error: /search/unstable/v0/course_list_search/
lms-1        | 2026-05-05 00:43:00,338 ERROR 104 [django.request] [user None] [ip None] log.py:253 - Internal Server Error: /search/unstable/v0/course_list_search/

```

This PR applies a quick fix by using `""` instead of `None` when we don't specify any particular search query.

I also updated the README.

Internal ref MNG-4952