### PR TITLE
Fix: respect course_org_filter when expanding organization facets using meilisearch

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '5.0.1'
+__version__ = '5.0.2'

--- a/search/api.py
+++ b/search/api.py
@@ -143,6 +143,7 @@ def course_discovery_search(
         field: search_fields[field]
         for field in search_fields if field in use_search_fields
     }
+    allowed_orgs = use_field_dictionary.copy().get("org")
     if field_dictionary:
         use_field_dictionary.update(field_dictionary)
     if enable_course_sorting_by_start_date:
@@ -168,6 +169,7 @@ def course_discovery_search(
         aggregation_terms=course_discovery_aggregations(),
         sort_by=sort_by,
         is_multivalue=is_multivalue,
+        allowed_orgs=allowed_orgs,
     )
 
     return results

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -718,8 +718,10 @@ class ElasticSearchEngine(SearchEngine):
 
         body = {"query": query}
 
+        # Strip "allowed_orgs" out of kwargs; it's not a valid Elasticsearch search parameter.
+        kwargs.pop("allowed_orgs", None)
+
         is_multivalue = kwargs.pop("is_multivalue", False)
-        allowed_orgs = kwargs.pop("allowed_orgs", [])
         if aggregation_terms:
             if is_multivalue:
                 body["aggs"] = _process_multivalue_aggregations(aggregation_terms, field_dictionary)

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -719,6 +719,7 @@ class ElasticSearchEngine(SearchEngine):
         body = {"query": query}
 
         is_multivalue = kwargs.pop("is_multivalue", False)
+        allowed_orgs = kwargs.pop("allowed_orgs", [])
         if aggregation_terms:
             if is_multivalue:
                 body["aggs"] = _process_multivalue_aggregations(aggregation_terms, field_dictionary)

--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -181,6 +181,7 @@ class MeilisearchEngine(SearchEngine):
         See meilisearch docs: https://www.meilisearch.com/docs/reference/api/search
         """
         is_multivalue = kwargs.pop("is_multivalue", False)
+        allowed_orgs = kwargs.pop("allowed_orgs", [])
         opt_params = get_search_params(
             field_dictionary=field_dictionary,
             filter_dictionary=filter_dictionary,
@@ -195,13 +196,14 @@ class MeilisearchEngine(SearchEngine):
         meilisearch_results = self.meilisearch_index.search(query_string, opt_params)
 
         if is_multivalue:
-            self._expand_facet_distibutions(field_dictionary, query_string, opt_params, meilisearch_results)
+            self._expand_facet_distibutions(field_dictionary, allowed_orgs, query_string, opt_params, meilisearch_results)
 
         return process_results(meilisearch_results, self.index_name)
 
     def _expand_facet_distibutions(
             self,
             field_dictionary: dict,
+            allowed_orgs: list,
             query_string: str,
             opt_params: dict,
             meilisearch_results: dict
@@ -212,12 +214,13 @@ class MeilisearchEngine(SearchEngine):
         for facet in field_dictionary.keys():
             expanded_facet_distribution = self._get_expanded_distribution(
                 query_string,
+                allowed_orgs,
                 facet,
                 opt_params.get("filter", []),
             )
             meilisearch_results.setdefault("facetDistribution", {})[facet] = expanded_facet_distribution
 
-    def _get_expanded_distribution(self, query: str, facet_to_exclude: str, filter_rules: list) -> dict:
+    def _get_expanded_distribution(self, query: str, allowed_orgs: list, facet_to_exclude: str, filter_rules: list) -> dict:
         """
         Run a secondary query excluding one facet to get its full distribution.
         Only return distribution data, without any actual results.
@@ -228,7 +231,13 @@ class MeilisearchEngine(SearchEngine):
             'limit': 0,
         }
         result = self.meilisearch_index.search(query, secondary_opt_params)
-        return result.get("facetDistribution", {}).get(facet_to_exclude, {})
+        facet_distribution = result.get("facetDistribution", {}).get(facet_to_exclude, {})
+        if facet_to_exclude == "org" and allowed_orgs:
+            allowed = set(allowed_orgs)
+            facet_distribution = {
+                org: count for org, count in facet_distribution.items() if org in allowed
+            }
+        return facet_distribution
 
     def remove(self, doc_ids, **kwargs):
         """

--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -196,7 +196,13 @@ class MeilisearchEngine(SearchEngine):
         meilisearch_results = self.meilisearch_index.search(query_string, opt_params)
 
         if is_multivalue:
-            self._expand_facet_distibutions(field_dictionary, allowed_orgs, query_string, opt_params, meilisearch_results)
+            self._expand_facet_distibutions(
+                field_dictionary,
+                allowed_orgs,
+                query_string,
+                opt_params,
+                meilisearch_results,
+            )
 
         return process_results(meilisearch_results, self.index_name)
 
@@ -220,7 +226,13 @@ class MeilisearchEngine(SearchEngine):
             )
             meilisearch_results.setdefault("facetDistribution", {})[facet] = expanded_facet_distribution
 
-    def _get_expanded_distribution(self, query: str, allowed_orgs: list, facet_to_exclude: str, filter_rules: list) -> dict:
+    def _get_expanded_distribution(
+            self,
+            query: str,
+            allowed_orgs: list,
+            facet_to_exclude: str,
+            filter_rules: list
+    ) -> dict:
         """
         Run a secondary query excluding one facet to get its full distribution.
         Only return distribution data, without any actual results.

--- a/search/tests/test_meilisearch.py
+++ b/search/tests/test_meilisearch.py
@@ -506,6 +506,26 @@ class EngineTests(django.test.TestCase):
         )
         self.assertDictEqual(aggregations["org"]["terms"], {"EDX": 2})
 
+    def test_get_expanded_distribution_filters_orgs_to_allowed(self):
+        engine = search.meilisearch.MeilisearchEngine(index='test_index')
+        engine.meilisearch_index.search = Mock(return_value={
+            "facetDistribution": {
+                "org": {"EDX": 2, "MITx": 1, "HarvardX": 3},  # More orgs than allowed
+            }
+        })
+
+        allowed_orgs = ["EDX", "MITx"]
+        facet_distribution = engine._get_expanded_distribution(  # pylint: disable=protected-access
+            query="",
+            allowed_orgs=allowed_orgs,
+            facet_to_exclude="org",
+            filter_rules=[],
+        )
+
+        # Only the allowed orgs are returned; HarvardX is filtered out
+        self.assertDictEqual(facet_distribution, {"EDX": 2, "MITx": 1})
+        self.assertEqual(set(facet_distribution.keys()), set(allowed_orgs))
+
     def test_single_value_search_narrows_selected_facet(self):
         engine = search.meilisearch.MeilisearchEngine(index='test_index')
         engine.meilisearch_index.search = Mock(side_effect=[

--- a/search/tests/test_meilisearch.py
+++ b/search/tests/test_meilisearch.py
@@ -459,8 +459,9 @@ class EngineTests(django.test.TestCase):
             'org = "EDX"',
         ]
         selected_facet = 'language'
+        allowed_orgs = ["EDX"]
         actual_distribution = engine._get_expanded_distribution(  # pylint: disable=protected-access
-            '', selected_facet, original_filter
+            '', allowed_orgs, selected_facet, original_filter
         )
         self.assertDictEqual(actual_distribution, multivalue_distribution)
         (query, opt_params), _ = engine.meilisearch_index.search.call_args  # pylint: disable=unused-variable


### PR DESCRIPTION
## Description

During testing with the catalog MFE, I discovered that the organizations filter does not respect the _course_org_filter_ configuration. Currently, all organizations are being returned and populated in the organization filter.

This issue occurs during the facet expansion logic, which removes filters for the target facet to retrieve its full distribution. However, the organization facet's distribution should not be fully expanded, as it must be constrained by the _course_org_filter_ configuration. This ensures the catalog only displays the specific organizations configured for the site. This filtering logic is natively implemented in the default Search Filter Generator: [lms_filter_generator.py](https://github.com/openedx/openedx-platform/blob/432e02cae358e5fae7c2310e776f5425f101083a/lms/lib/courseware_search/lms_filter_generator.py#L41-L43).

To resolve this, I implemented a mechanism to propagate the _course_org_filter_ initially returned by the Search Filter Generator (if it exists in the field_dictionary). Now, when the logic expands the full distribution for organizations, it correctly filters them based on the valid organizations allowed for the site.

## Current and Expected Behavior

- **Current Behavior:** The catalog MFE correctly limits the visible courses to those matching the _course_org_filter_ configuration. However, the organization filter sidebar still retrieves and displays the full distribution of all organizations. For example, if the site is configured to only show the _demo_ and _other_ orgs, the _openedx_ org incorrectly still appears in the filter sidebar. (See current screenshot below).

<img width="1601" height="754" alt="image" src="https://github.com/user-attachments/assets/43a27adf-cd96-4faf-b74f-e5c17353b49f" />

- **Expected Behavior:** With these changes, the organization filter sidebar is properly constrained, hiding organizations that are not explicitly permitted by the site configuration. (See expected screenshot below).

<img width="1601" height="754" alt="Screenshot From 2026-06-24 11-56-38" src="https://github.com/user-attachments/assets/0896a1f1-3d97-41da-9833-060befc86c07" />

## How to Test

1. Create several organizations and courses belonging to those organizations.
2. Configure your site to include only a subset of those organizations by setting the _course_org_filter_ in the site configuration.
3. Navigate to the course catalog and verify that only the permitted organizations appear in the organization filter sidebar.